### PR TITLE
initial pagination setup for frontend dataset table

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ features/csv-uploader:
  - create initial file uploader UIs, simple file validation
  - create new alert component (this would be used sitewide to display messages to the user); for now used to display messages relating to the file upload
 
-
 features/initialPlantApiSetup:
  - create initial Plant and Family models
  - define enums for model properties: TaxonomicStatus and VerbatimTaxonRanks
@@ -66,9 +65,13 @@ features/initialPlantApiSetup:
  - add temporary test data to PlantsController (to be replaced by DB)
  - add API versioning support (Asp.Versioning.Mvc, Asp.Versioning.Mvc.ApiExplorer)
 
-
  features/frontendInitialApiConnection:
   - add axios dependency for api calls
   - create basic axios api calls and singleton; add some error catching
   - add new test data to the backend PlantsController sample
   - display sample data on the frontend (split in 2 sections, 1 displaying record received via ID, and the next section displaying all records)
+
+ features/paginationSetupV1:
+  - create new TableContainer component: to hold table + pagination
+  - create new Pagination component: generic pagination widget - to be used for custom pagination of table datasets
+  - install daisyUI (used to remove large css classes that are common with TailwindCSS); intrigued in testing it out to see if it should be used in future projects

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.10.0",
+        "daisyui": "^5.0.46",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-data-table-component": "^7.7.0",
@@ -22,7 +23,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.1.11",
         "typescript": "^5"
       }
     },
@@ -1029,6 +1030,13 @@
         "tailwindcss": "4.1.8"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.8.tgz",
@@ -1288,6 +1296,13 @@
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.8"
       }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -2459,6 +2474,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/daisyui": {
+      "version": "5.0.46",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.46.tgz",
+      "integrity": "sha512-vMDZK1tI/bOb2Mc3Mk5WpquBG3ZqBz1YKZ0xDlvpOvey60dOS4/5Qhdowq1HndbQl7PgDLDYysxAjjUjwR7/eQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5960,9 +5984,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
-      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.10.0",
+    "daisyui": "^5.0.46",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-data-table-component": "^7.7.0",
@@ -23,7 +24,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.1.11",
     "typescript": "^5"
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "daisyui";
 
 :root {
   --background: #ffffff;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Table from "@/components/Table";
+import TableContainer from "@/components/TableContainer";
 import { getAllPlants, getPlantById } from "@/services/plantService";
 import { Plant } from "@/types/Plant";
 import dynamic from "next/dynamic";
@@ -26,9 +27,10 @@ export default async function Home() {
         
         <section>
           <h2>Multi-record table</h2>
-          <Table
+          {/* <Table
             plants={plants}
-          ></Table>
+          ></Table> */}
+          <TableContainer plants={plants} />
         </section>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,38 @@
+type Props = {
+    activePage: number,
+    totalPages: number,
+    onPageChange: (page: number) => void,
+};
+
+export default function Pagination(props: Props) {
+    // make sure that the activePage number is within the accepted parameters (between page 1 to totalPages) before making any updates
+    function testPageParams(page: number){
+        if(page > 0 && page <= props.totalPages){
+            props.onPageChange(page);
+        }
+    }
+
+    return (
+        <nav aria-label="Pagination" className="flex flex-col items-center mt-4 mb-4">
+            <ul className="pagination join-horizontal join join-item">
+                <li>
+                    <button aria-label="First page" className="join-item btn" onClick={() => testPageParams(1)}>First</button>
+                </li>
+                <li>
+                    <button aria-label="Previous page" className="join-item btn" onClick={() => testPageParams(props.activePage - 1)}>Previous</button>
+                </li>
+                {/* <li>...</li> */}
+                <li>
+                    <button aria-current="page" className="join-item btn btn-active">{`${props.activePage} / ${props.totalPages}`}</button>
+                </li>
+                {/* <li>...</li> */}
+                <li>
+                    <button aria-label="Next page" className="join-item btn" onClick={() => testPageParams(props.activePage + 1)}>Next</button>
+                </li>
+                <li>
+                    <button aria-label="Last page" className="join-item btn" onClick={() => testPageParams(props.totalPages)}>Last</button>
+                </li>
+            </ul>
+        </nav>
+    );
+}

--- a/frontend/src/components/TableContainer.tsx
+++ b/frontend/src/components/TableContainer.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Plant } from "@/types/Plant";
+import Table from "./Table";
+import Pagination from "./Pagination";
+import { useState } from "react";
+
+type Props = {
+    plants: Plant[]
+};
+
+export default function TableContainer(props: Props) {
+    const [activePage, setActivePage] = useState(1);
+
+    function setNewPage(page: number){
+        setActivePage(page);
+    }
+    
+    return (
+        <div>
+            <Table
+                plants={props.plants}
+            />
+            <Pagination
+                activePage={activePage}
+                totalPages={props.plants.length / 2}
+                onPageChange={setNewPage}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
  - create new TableContainer component: to hold table + pagination
  - create new Pagination component: generic pagination widget - to be used for custom pagination of table datasets
  - install daisyUI (used to remove large css classes that are common with TailwindCSS); intrigued in testing it out to see if it should be used in future projects