### PR TITLE
refactor frontend to accomodate plants API and query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ features/initialPlantApiSetup:
  features/backendPaginationAPI:
   - remove the GetAll() PlantsController method which was used in initial testing
   - create new GetPlants() PlantsController with query params (page, and pageSize); going forward, this will be the way to request paginated or filtered plants results
+
+features/frontendApiUpdates:
+ - update the plantService getAllPlants() function to reflect the new paginated/filterable API created on the backend in the previous "features" branch (request plant data from api via query params)
+ - refactor frontend components to work with new api-related interfaces:
+  - PaginateConfig: contains pagination properties (current page, # of records / page)
+  - PaginationFilterResults: DTO to hold data (and total # of pages) received from the API

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,15 +1,16 @@
 import Table from "@/components/Table";
 import TableContainer from "@/components/TableContainer";
-import { getAllPlants, getPlantById } from "@/services/plantService";
+import { getPlants, getPlantById } from "@/services/plantService";
+import { PaginationFilterResults } from "@/types/PaginationFilterResults";
 import { Plant } from "@/types/Plant";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import DataTable from "react-data-table-component";
 
 export default async function Home() {
-  // TESTING PURPOSES - validating initial backend api's
-  // get all plants from the api
-  const plants: Plant[] = await getAllPlants();
+  const initialPage = 1;
+  const pageSize = 3;
+  // const plants: PaginationFilterResults<Plant> = await getPlants(currentPage, pageSize);
   // get plant by ID from the api;
   const plant: Plant = await getPlantById(6);
   // normalize the plant result for predictable outputs
@@ -18,19 +19,20 @@ export default async function Home() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <section>
+        {/* <section>
           <h2>Single record table (get by ID)</h2>
           <Table
             plants={soloPlant}
           ></Table>
-        </section>
+        </section> */}
         
         <section>
           <h2>Multi-record table</h2>
-          {/* <Table
-            plants={plants}
-          ></Table> */}
-          <TableContainer plants={plants} />
+          <TableContainer
+            // plants={plants}
+            initialPage = {initialPage}
+            pageSize = {pageSize}
+          />
         </section>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,13 +1,16 @@
+import { PaginateConfig } from "@/types/PaginateConfig";
+
 type Props = {
     activePage: number,
-    totalPages: number,
+    totalPages: number | undefined,
+    paginateConfig: PaginateConfig
     onPageChange: (page: number) => void,
 };
 
 export default function Pagination(props: Props) {
     // make sure that the activePage number is within the accepted parameters (between page 1 to totalPages) before making any updates
-    function testPageParams(page: number){
-        if(page > 0 && page <= props.totalPages){
+    function getSelectedPage(page: number){
+        if(props?.totalPages && page > 0 && page <= props.totalPages){
             props.onPageChange(page);
         }
     }
@@ -16,10 +19,10 @@ export default function Pagination(props: Props) {
         <nav aria-label="Pagination" className="flex flex-col items-center mt-4 mb-4">
             <ul className="pagination join-horizontal join join-item">
                 <li>
-                    <button aria-label="First page" className="join-item btn" onClick={() => testPageParams(1)}>First</button>
+                    <button aria-label="First page" className="join-item btn" onClick={() => getSelectedPage(1)}>First</button>
                 </li>
                 <li>
-                    <button aria-label="Previous page" className="join-item btn" onClick={() => testPageParams(props.activePage - 1)}>Previous</button>
+                    <button aria-label="Previous page" className="join-item btn" onClick={() => getSelectedPage(props.activePage - 1)}>Previous</button>
                 </li>
                 {/* <li>...</li> */}
                 <li>
@@ -27,10 +30,10 @@ export default function Pagination(props: Props) {
                 </li>
                 {/* <li>...</li> */}
                 <li>
-                    <button aria-label="Next page" className="join-item btn" onClick={() => testPageParams(props.activePage + 1)}>Next</button>
+                    <button aria-label="Next page" className="join-item btn" onClick={() => getSelectedPage(props.activePage + 1)}>Next</button>
                 </li>
                 <li>
-                    <button aria-label="Last page" className="join-item btn" onClick={() => testPageParams(props.totalPages)}>Last</button>
+                    {/* <button aria-label="Last page" className="join-item btn" onClick={() => getSelectedPage(props?.totalPages)}>Last</button> */}
                 </li>
             </ul>
         </nav>

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { PaginationFilterResults } from "@/types/PaginationFilterResults";
 import { Plant } from "@/types/Plant";
 import DataTable from "react-data-table-component";
 import { ExpanderComponentProps } from "react-data-table-component";
 
 type Props = {
     // your props here
-    plants: Plant[]
+    plants: Plant[] | undefined
 }
 
 export default function Table(props: Props){
@@ -49,7 +50,7 @@ export default function Table(props: Props){
     return(
         <DataTable
           columns={tableColumns}
-          data={props.plants}
+          data={props.plants ? props.plants : []}
           selectableRows
           // pagination -> causes hydration errors + no longer needed; will create custom pagination to deal with larga dataset
           // expandableRows

--- a/frontend/src/components/TableContainer.tsx
+++ b/frontend/src/components/TableContainer.tsx
@@ -3,27 +3,54 @@
 import { Plant } from "@/types/Plant";
 import Table from "./Table";
 import Pagination from "./Pagination";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { PaginationFilterResults } from "@/types/PaginationFilterResults";
+import { getPlants } from "@/services/plantService";
+import { PaginateConfig } from "@/types/PaginateConfig";
 
 type Props = {
-    plants: Plant[]
+    // plants: Plant[]
+    // plants: PaginationFilterResults<Plant>
+    initialPage: number,
+    pageSize: number,
 };
 
 export default function TableContainer(props: Props) {
-    const [activePage, setActivePage] = useState(1);
+    // const [currentPage, setCurrentPage] = useState(1);
+    const [plantsDto, setPlantsDto] = useState<PaginationFilterResults<Plant>>();
+    const [paginateConfig, setPaginateConfig] = useState<PaginateConfig>({
+        currentPage: props.initialPage,
+        pageSize: props.pageSize,
+    });
 
+    // update the current page based on user (click event) inputs on the pagination controls
     function setNewPage(page: number){
-        setActivePage(page);
+        // setCurrentPage(page);
+        setPaginateConfig(prev => ({
+            ...prev,
+            currentPage: page
+        }));
     }
+
+    useEffect( () => {
+        // request new records from API when the user selects a new page from pagination form
+        async function fetchPlants(){
+            const plantsApiDto: PaginationFilterResults<Plant> = await getPlants(props.initialPage, props.pageSize);
+            setPlantsDto( plantsApiDto );
+        }
+        fetchPlants();
+    }, [paginateConfig.currentPage]);
     
     return (
         <div>
             <Table
-                plants={props.plants}
+                // plants={props.plants}
+                plants={plantsDto?.data}
             />
             <Pagination
-                activePage={activePage}
-                totalPages={props.plants.length / 2}
+                paginateConfig={paginateConfig}
+                activePage={paginateConfig.currentPage}
+                totalPages={plantsDto?.totalPages}
                 onPageChange={setNewPage}
             />
         </div>

--- a/frontend/src/services/plantService.ts
+++ b/frontend/src/services/plantService.ts
@@ -1,10 +1,15 @@
 import { Plant } from '@/types/Plant';
 import axiosInstance from './axiosInstance';
+import { PaginationFilterResults } from '@/types/PaginationFilterResults';
 
-// Get all plants
-export async function getAllPlants(): Promise<Plant[]> {
+// Query API endpoint for paginated plants (by default, ask for records starting on page 1, with 3 records / page)
+export async function getPlants(page: number = 1, pageSize: number = 3): Promise<PaginationFilterResults<Plant>> {
   try {
-    const response = await axiosInstance.get<Plant[]>('/plants');
+    const response = await axiosInstance.get<PaginationFilterResults<Plant>>('/plants', {
+      params: { page, pageSize }
+    });
+
+    console.log(response.data);
 
     return response.data;
   } catch (error: any) {

--- a/frontend/src/types/PaginateConfig.ts
+++ b/frontend/src/types/PaginateConfig.ts
@@ -1,0 +1,5 @@
+export interface PaginateConfig{
+   currentPage : number,
+   pageSize: number,
+   // totalPages: number,
+}

--- a/frontend/src/types/PaginationFilterResults.ts
+++ b/frontend/src/types/PaginationFilterResults.ts
@@ -1,0 +1,4 @@
+export interface PaginationFilterResults<T>{
+   data: T[],
+   totalPages: number,
+}


### PR DESCRIPTION
 - update the plantService getAllPlants() function to reflect the new paginated/filterable API created on the backend in the previous "features" branch (request plant data from api via query params)
 - refactor frontend components to work with new api-related interfaces:
  - PaginateConfig: contains pagination properties (current page, # of records / page)
  - PaginationFilterResults: DTO to hold data (and total # of pages) received from the API