### PR TITLE
update api request params to use current pagination page number

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,6 @@ features/frontendApiUpdates:
 features/backendCORS
  - fix issues related to frontend and CORS
  - add Origin CORS policy for development environment
+
+features/frontendApiRequests
+ - update api requests to retrieve dataset based on current page

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,7 +9,7 @@ import DataTable from "react-data-table-component";
 
 export default async function Home() {
   const initialPage = 1;
-  const pageSize = 3;
+  const pageSize = 2;
   // const plants: PaginationFilterResults<Plant> = await getPlants(currentPage, pageSize);
   // get plant by ID from the api;
   const plant: Plant = await getPlantById(6);

--- a/frontend/src/components/TableContainer.tsx
+++ b/frontend/src/components/TableContainer.tsx
@@ -35,7 +35,7 @@ export default function TableContainer(props: Props) {
     useEffect( () => {
         // request new records from API when the user selects a new page from pagination form
         async function fetchPlants(){
-            const plantsApiDto: PaginationFilterResults<Plant> = await getPlants(props.initialPage, props.pageSize);
+            const plantsApiDto: PaginationFilterResults<Plant> = await getPlants(paginateConfig.currentPage, paginateConfig.pageSize);
             setPlantsDto( plantsApiDto );
         }
         fetchPlants();


### PR DESCRIPTION
 - update api requests to retrieve dataset based on current page
 - update the plants dataset api request ( GetPlants() ) to use paginateConfig state instead of props (as initial props values are passed into the state)