### PR TITLE
minor updates; convert enum properties to their string names

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,18 +86,24 @@ features/frontendApiUpdates:
   - PaginateConfig: contains pagination properties (current page, # of records / page)
   - PaginationFilterResults: DTO to hold data (and total # of pages) received from the API
 
-features/backendCORS
+features/backendCORS:
  - fix issues related to frontend and CORS
  - add Origin CORS policy for development environment
 
-features/frontendApiRequests
+features/frontendApiRequests:
  - update api requests to retrieve dataset based on current page
 
-features/frontendPaginationUpdates
+features/frontendPaginationUpdates:
  - enable the "Last" page button from the pagination component
  - rename the "activePage" props to "currentPage" for easier readability
 
-features/databaseConnectionSetup
+features/databaseConnectionSetup:
  - add .env file for DB connection
  - update appsettings.json in preparation for DB connection
  - add SQLServer package (as of this branch, will use a local MS SQL database; may change in future if deployed somewhere -> depending on hosting costs)
+ - created database context file for the connection
+
+features/dbConnectionTests:
+ - increase the number of records / page that the frontend asks for to 30
+ - update the PlantsController so it returns the actual total # of pages (initially it was returning "1")
+ - configured EF Core to automatically convert enum properties (TaxonomicStatus and VerbatimTaxonRanks) to their string names for storage in the database and vice versa

--- a/backend/Controllers/PlantsController.cs
+++ b/backend/Controllers/PlantsController.cs
@@ -61,7 +61,7 @@ public class PlantsController : ControllerBase{
                 .ToListAsync();
             var result = new PaginationFilterResults<Plant>{
                 Data = plants,
-                TotalPages = 1
+                TotalPages = totalPages
             };
 
             return Ok(result);

--- a/backend/Models/PlantInventoryDbContext.cs
+++ b/backend/Models/PlantInventoryDbContext.cs
@@ -5,6 +5,7 @@ public class PlantInventoryDbContext : DbContext
 {
     public PlantInventoryDbContext(DbContextOptions<PlantInventoryDbContext> options) : base(options) { }
 
+    // store Plant enums TaxonomicStatus and VerbatimTaxonRanks as strings in the database (for readable varchar fields)
     protected override void OnModelCreating(ModelBuilder modelBuilder){
         modelBuilder.Entity<Plant>()
         .Property(p => p.TaxonomicStatus)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,16 +1,11 @@
 import Table from "@/components/Table";
 import TableContainer from "@/components/TableContainer";
-import { getPlants, getPlantById } from "@/services/plantService";
-import { PaginationFilterResults } from "@/types/PaginationFilterResults";
+import { getPlantById } from "@/services/plantService";
 import { Plant } from "@/types/Plant";
-import dynamic from "next/dynamic";
-import Image from "next/image";
-import DataTable from "react-data-table-component";
 
 export default async function Home() {
   const initialPage = 1;
-  const pageSize = 2;
-  // const plants: PaginationFilterResults<Plant> = await getPlants(currentPage, pageSize);
+  const pageSize = 30;
   // get plant by ID from the api;
   const plant: Plant = await getPlantById(6);
   // normalize the plant result for predictable outputs
@@ -19,17 +14,9 @@ export default async function Home() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        {/* <section>
-          <h2>Single record table (get by ID)</h2>
-          <Table
-            plants={soloPlant}
-          ></Table>
-        </section> */}
-        
         <section>
           <h2>Multi-record table</h2>
           <TableContainer
-            // plants={plants}
             initialPage = {initialPage}
             pageSize = {pageSize}
           />


### PR DESCRIPTION
 - increase the number of records / page that the frontend asks for to 30
 - update the PlantsController so it returns the actual total # of pages (initially it was returning "1")
 - configured EF Core to automatically convert enum properties (TaxonomicStatus and VerbatimTaxonRanks) to their string names for storage in the database and vice versa