### PR TITLE
create initial file upload system

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
 
-## App though process & progression
+## App thought process & progression
 - Initial system thoughts:
  - Frontend:
   - CSV File Upload: Accept CSV files from users via drag & drop or file selection, then send securely to the backend.
@@ -107,3 +107,11 @@ features/dbConnectionTests:
  - increase the number of records / page that the frontend asks for to 30
  - update the PlantsController so it returns the actual total # of pages (initially it was returning "1")
  - configured EF Core to automatically convert enum properties (TaxonomicStatus and VerbatimTaxonRanks) to their string names for storage in the database and vice versa
+
+features/handleFileUpload:
+ - create file upload api endpoint used to retrieve CSV file from the frontend
+ - set up POST request on the frontend to send the CSV file to the backend
+ - enforce Kestrel server body request size limits (default were too small for the large dataset file)
+ - enforce form data size limits, specifically for file uploads - default is 30MB which is much lower than what I need to upload (current dataset csv is ~360MB)
+ - create system that reads the file;
+ - TODO: validate data and insert it into the database

--- a/backend/Controllers/FileUploadController.cs
+++ b/backend/Controllers/FileUploadController.cs
@@ -1,0 +1,37 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PlantInventoryApi.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
+public class FileUploadController : ControllerBase{
+    private readonly ICsvPlantImportService _csvImportService;
+
+    public FileUploadController(ICsvPlantImportService csvImportService){
+        _csvImportService = csvImportService;
+    }
+
+    [RequestSizeLimit(419430400)] // up to 400MB allowed per request body
+    [HttpPost("upload-csv")]
+    public async Task<IActionResult> UploadCsv(IFormFile file){
+        if (file == null || file.Length == 0){
+            return BadRequest("No file was uploaded.");
+        }
+            
+        if (!file.FileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase)){
+            return BadRequest("Uploaded file is not a CSV.");
+        }
+
+        // call the CSV import service
+        var result = await _csvImportService.ImportAsync(file);
+
+        // return result
+        if (result.HasErrors){
+            return BadRequest(new { status = "error", message = "Import failed", errors = result.Errors });
+        }
+            
+        return Ok(new { status = "success", importedCount = result.ImportedCount });
+    }
+}

--- a/backend/Models/PlantCsv.cs
+++ b/backend/Models/PlantCsv.cs
@@ -1,0 +1,11 @@
+namespace PlantInventoryApi.Models;
+
+// Model used in record extration from uploaded plants CSV file
+public class PlantCsv{
+    public string scientificName { get; set; } = string.Empty;
+    public string family { get; set; } = string.Empty;
+    public string verbatimTaxonRank { get; set; } = string.Empty;
+    public string taxonomicStatus { get; set; } = string.Empty;
+    public string taxonRemarks { get; set; } = string.Empty;
+    public string references { get; set; } = string.Empty;
+}

--- a/backend/PlantInventoryApi.csproj
+++ b/backend/PlantInventoryApi.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />

--- a/backend/Services/CsvImportResult.cs
+++ b/backend/Services/CsvImportResult.cs
@@ -1,0 +1,5 @@
+public class CsvImportResult{
+    public int ImportedCount { get; set; }
+    public List<string> Errors { get; set; } = new();
+    public bool HasErrors => Errors.Count > 0;
+}

--- a/backend/Services/CsvPlantImportService.cs
+++ b/backend/Services/CsvPlantImportService.cs
@@ -1,0 +1,73 @@
+using CsvHelper;
+using Microsoft.AspNetCore.Http;
+using PlantInventoryApi;
+using PlantInventoryApi.Models;
+using System.Globalization;
+using System.Threading.Tasks;
+
+public class CsvPlantImportService : ICsvPlantImportService{
+    private readonly PlantInventoryDbContext _context;
+
+    public CsvPlantImportService(PlantInventoryDbContext context){
+        _context = context;
+    }
+
+// ***does this need to be async?***
+    public async Task<CsvImportResult> ImportAsync(IFormFile csvFile){
+        var result = new CsvImportResult();
+        using var stream = csvFile.OpenReadStream();
+        using var reader = new StreamReader(stream);
+        using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
+        
+        // used to compare & confirm the CSV file column headers match with the model property names, so we can properly parse the data
+        // var expectedCsvHeaders = typeof(PlantCsv).GetProperties().Select( p => p.Name).ToArray();
+        
+        // hold unique family names regardless of their capitalization (in case the csv data is odd / not standardised)
+        var uniqueFamilies = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+        // to hold initial CSV records until they are ready to be insterted into the database
+        var csvRecords = new List<PlantCsv>();
+        // hold database ready plant records
+        var plantsDbReady = new List<Plant>();
+        // keep track of the current csv row
+        var rowNum = 1;
+
+        // don't go further if the file is empty or does not have a header row
+        if(!await csv.ReadAsync() || !csv.ReadHeader()){
+            result.Errors.Add("The CSV file does not have a header row, or it is empty.");
+            return result;
+        }
+
+        // check that CSV headers match what I am expecting (in PlantCsv model)
+        // ...
+
+        await foreach(var record in csv.GetRecordsAsync<PlantCsv>()){
+            uniqueFamilies.Add(record.family);
+            csvRecords.Add(record);
+            
+            rowNum++;
+        }
+
+        // foreach(var family in uniqueFamilies){
+        //     Console.WriteLine($"family = {family}");
+        //     // Console.WriteLine($"scientificName={record.scientificName} | family={record.family} | verbatimTaxonRank={record.verbatimTaxonRank} | taxonomicStatus={record.taxonomicStatus} | taxonRemarks={record.taxonRemarks} | references={record.references}");
+        // }
+        // Console.WriteLine($"csvRecords = {csvRecords.Count}");
+        // Console.WriteLine($"uniqueFamilies={uniqueFamilies.Count}");
+        // Console.WriteLine($"*** we broke out of the foreach loop ***; rowNum = {rowNum}");
+        // Console.WriteLine($"uniqueFamilies = {uniqueFamilies}");
+
+        // for (int i = 0; i < csvRecords.Count; i++)
+        // {
+        //     Console.WriteLine($"csvRecords[{i}.scientificName] = {csvRecords[i].scientificName}");
+        // }
+ 
+
+        // TODO: implement CSV parsing, validation, and DB insert logic here.
+        // This is your main import workflow.
+        // For now, just simulate success.
+        result.ImportedCount = 0;
+        // result.Errors.Add("Fake error example"); // for testing
+
+        return result;
+    }
+}

--- a/backend/Services/ICsvPlantImportService.cs
+++ b/backend/Services/ICsvPlantImportService.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+public interface ICsvPlantImportService
+{
+    Task<CsvImportResult> ImportAsync(IFormFile csvFile);
+}

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import Alert from "./Alert";
 import { AlertType } from "@/types/AlertType";
 import { AlertContent } from "@/types/AlertContent";
+import { uploadPlantCsvFile } from "@/services/plantService";
 
 type Props = {
     
@@ -27,7 +28,6 @@ export default function FileUpload(props: Props) {
                     content: `"${userFile.name}" is ready to be uploaded!`,
                     type: AlertType.info
                 });
-
                 return;
             }
             else{
@@ -44,8 +44,23 @@ export default function FileUpload(props: Props) {
         }
     }
 
-    const handleFileUpload = () => {
+    const handleFileUpload = async () => {
         console.log("Uploading time");
+
+        if(!selectedFile){
+            setAlertMessage({
+                content: `No file is selected!`,
+                type: AlertType.error
+            });
+            
+            return;
+        }
+
+        try{
+            const response = await uploadPlantCsvFile(selectedFile);
+        }catch(error: any){
+            throw error;
+        }
     };
 
     return (

--- a/frontend/src/services/axiosInstance.ts
+++ b/frontend/src/services/axiosInstance.ts
@@ -6,10 +6,10 @@ const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5242/a
 
 const axiosInstance = axios.create({
   baseURL,
-  headers: {
-    'Content-Type': 'application/json',
-    // Add other default headers here if needed
-  },
+  // headers: {
+  //   'Content-Type': 'application/json',
+  //   // Add other default headers here if needed
+  // },
   // timeout: 10000, // Optional: set a timeout (ms)
 });
 

--- a/frontend/src/services/plantService.ts
+++ b/frontend/src/services/plantService.ts
@@ -5,8 +5,13 @@ import { PaginationFilterResults } from '@/types/PaginationFilterResults';
 // Query API endpoint for paginated plants (by default, ask for records starting on page 1, with 3 records / page)
 export async function getPlants(page: number = 1, pageSize: number = 3): Promise<PaginationFilterResults<Plant>> {
   try {
-    const response = await axiosInstance.get<PaginationFilterResults<Plant>>('/plants', {
-      params: { page, pageSize }
+    const response = await axiosInstance.get<PaginationFilterResults<Plant>>(
+      '/plants',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        params: { page, pageSize },
     });
 
     console.log(response.data);
@@ -30,7 +35,14 @@ export async function getPlants(page: number = 1, pageSize: number = 3): Promise
 // Get plant by ID
 export async function getPlantById(id: number): Promise<Plant> {
   try{
-    const response = await axiosInstance.get<Plant>(`/plants/${id}`);
+    const response = await axiosInstance.get<Plant>(
+      `/plants/${id}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
 
     return response.data;
   } catch (error: any) {
@@ -45,5 +57,31 @@ export async function getPlantById(id: number): Promise<Plant> {
       console.error('Axios error:', error.message);
       throw new Error('An unexpected error occurred.');
     }
+  }
+}
+
+// change the "any" Promise to something more relevant later on (after deciding what to send back from the backend)
+export async function uploadPlantCsvFile(file: File): Promise<any> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  for (const [key, value] of formData.entries()) {
+    console.log(key, value); // should see "file" and the File object
+  }
+
+  try{
+    const response = await axiosInstance.post(
+      `FileUpload/upload-csv`,
+      formData,
+      {
+        headers: {
+          // 'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
+
+    return response.data;
+  }catch(error: any){
+    throw error;
   }
 }


### PR DESCRIPTION
 - create file upload api endpoint used to retrieve CSV file from the frontend
 - set up POST request on the frontend to send the CSV file to the backend
 - enforce Kestrel server body request size limits (default were too small for the large dataset file)
 - enforce form data size limits, specifically for file uploads - default is 30MB which is much lower than what I need to upload (current dataset csv is ~360MB)
 - create system that reads the file;
 - TODO: validate data and insert it into the database